### PR TITLE
Workflow step "Publish test results" now continues on error

### DIFF
--- a/.github/workflows/RunTests.yaml
+++ b/.github/workflows/RunTests.yaml
@@ -29,5 +29,6 @@ jobs:
       shell: pwsh
     - name: Publish test results
       uses: EnricoMi/publish-unit-test-result-action/composite@v1
+      continue-on-error: true
       with:
         files: testResults.xml


### PR DESCRIPTION
If the build step Publish test results fails for some reason, the whole job should not fail. Publishing the test results in a comment is just a nice feature, not required.

This change make this step continue even if it fails.

Closes #225