### PR TITLE
Updated module version to 2.1.0

### DIFF
--- a/Docs/bicep-version-comparison.md
+++ b/Docs/bicep-version-comparison.md
@@ -4,9 +4,9 @@ When Bicep PowerShell `v1.3.0` was released the official [Bicep](https://github.
 
 The table below shows which version of the Bicep assemblies and BicepNet that are used for each version of the module.
 
-
 | Bicep PowerShell version | Bicep assembly version | BicepNet Version |
 | --- | --- | -- |
+| `2.1.0` | `0.4.1008` | `1.0.6` |
 | `2.0.0` | `0.4.451` | `1.0.4` |
 | `2.0.0-Preview2` | `0.4.451` | `1.0.4` |
 | `2.0.0-Preview1` | `0.4.63` | `1.0.2` |

--- a/Docs/bicep-version-comparison.md
+++ b/Docs/bicep-version-comparison.md
@@ -6,7 +6,7 @@ The table below shows which version of the Bicep assemblies and BicepNet that ar
 
 | Bicep PowerShell version | Bicep assembly version | BicepNet Version |
 | --- | --- | -- |
-| `2.1.0` | `0.4.1008` | `1.0.6` |
+| `2.1.0` | `0.4.1008` | `1.0.7` |
 | `2.0.0` | `0.4.451` | `1.0.4` |
 | `2.0.0-Preview2` | `0.4.451` | `1.0.4` |
 | `2.0.0-Preview1` | `0.4.63` | `1.0.2` |

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Commands implemented:
 - [New-BicepParameterFile](./Docs/Help/New-BicepParameterFile.md)
 - [Update-BicepParameterFile](./Docs/Help/Update-BicepParameterFile.md)
 - [Test-BicepFile](./Docs/Help/Test-BicepFile.md)
+- [Publish-Bicep](./Docs/Help/Publish-Bicep.md)
+- [Restore-Bicep](./Docs/Help/Restore-Bicep.md)
 - [Convert-BicepParamsToDecoratorStyle](./Docs/Help/Convert-BicepParamsToDecoratorStyle.md) (Decommissioned in `v1.5.0`)
 
 >**Note:** Starting with version `1.3.0` of the Bicep PowerShell module the cmdlets `Build-Bicep` and `ConvertTo-Bicep` uses the assemblies from the official [Bicep](https://github.com/Azure/bicep) repository instead of wrapping the Bicep CLI. When new Bicep versions are released there will be a slight delay before the PowerShell module gets tested updated with the latest assemblies. If new functionality is added to Bicep CLI before the PowerShell module supports it, use `Install-BicepCLI` to install the latest Bicep CLI version and use the CLI while waiting for an updated PowerShell module.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,6 @@ This project is currently maintained by the following coders:
 
 <!-- References -->
 [BicepIcon]: logo/BicePS_40px.png
-[Bicep]: https://img.shields.io/badge/Bicep-v2.0.0-blue
+[Bicep]: https://img.shields.io/badge/Bicep-v2.1.0-blue
 [BicepDownloads]: https://img.shields.io/powershellgallery/dt/Bicep
 [BicepGallery]: https://www.powershellgallery.com/packages/Bicep/

--- a/Source/Bicep.psd1
+++ b/Source/Bicep.psd1
@@ -12,7 +12,7 @@
 RootModule = 'Bicep.psm1'
 
 # Version number of this module.
-ModuleVersion = '2.0.0'
+ModuleVersion = '2.1.0'
 
 # Supported PSEditions
 CompatiblePSEditions = @('Core')
@@ -95,7 +95,9 @@ FunctionsToExport = @(
     'Convert-BicepParamsToDecoratorStyle',
     'New-BicepParameterFile',
     'Update-BicepParameterFile',
-    'Test-BicepFile'
+    'Test-BicepFile',
+    'Publish-Bicep',
+    'Restore-Bicep'
 )
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.

--- a/scripts/downloadDependencies.ps1
+++ b/scripts/downloadDependencies.ps1
@@ -1,7 +1,7 @@
 [cmdletbinding()]
 param (
     [Parameter()]
-    $BicepNetUrl = 'https://github.com/PSBicep/BicepNet/releases/download/v1.0.4/BicepNet.PS.zip',
+    $BicepNetUrl = 'https://github.com/PSBicep/BicepNet/releases/download/v1.0.6/BicepNet.PS.zip',
     
     [Parameter(DontShow)]
     $BaseUri = 'https://api.github.com'

--- a/scripts/downloadDependencies.ps1
+++ b/scripts/downloadDependencies.ps1
@@ -1,7 +1,7 @@
 [cmdletbinding()]
 param (
     [Parameter()]
-    $BicepNetUrl = 'https://github.com/PSBicep/BicepNet/releases/download/v1.0.6/BicepNet.PS.zip',
+    $BicepNetUrl = 'https://github.com/PSBicep/BicepNet/releases/download/v1.0.7/BicepNet.PS.zip',
     
     [Parameter(DontShow)]
     $BaseUri = 'https://api.github.com'


### PR DESCRIPTION
Updated module version:

- Bumped version in manifest
- Bumped version in README shield
- Added new version to version comparison docs
- Updated downloadDependencies.ps1 to download BicepNet 1.0.6