### PR TITLE
Added new command `Get-BicepConfig`

### DIFF
--- a/Docs/Help/Get-BicepConfig.md
+++ b/Docs/Help/Get-BicepConfig.md
@@ -1,0 +1,100 @@
+---
+external help file: Bicep-help.xml
+Module Name: Bicep
+online version:
+schema: 2.0.0
+---
+
+# Get-BicepConfig
+
+## SYNOPSIS
+Command used to find the bicepconfig.json and configuration in use
+
+## SYNTAX
+
+```
+Get-BicepConfig [[-Path] <String>] [[-Scope] <String>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Command used to find the bicepconfig.json file in use and the current configuration. Shows either the configuration in the local bicepconfig.json file, the merged config or the default config.
+
+## EXAMPLES
+
+### Example 1 - Get the default bicepconfig
+```powershell
+$bicepConfig=Get-BicepConfig -Scope Default
+$bicepConfig.Config
+```
+
+Gets the default configuration built in to Bicep
+
+### Example 2 - Get the merged bicepconfig
+```powershell
+$bicepConfig=Get-BicepConfig -Scope Merged -Path c:\bicepTemplates\storage.bicep
+$bicepConfig.Config
+```
+
+Gets the merged configuration in use for a Bicep file
+
+### Example 3 - Get the local bicepconfig
+```powershell
+$bicepConfig=Get-BicepConfig -Scope Local -Path c:\bicepTemplates\storage.bicep
+$bicepConfig.Config
+```
+
+Gets the local configuration in use for a Bicep file
+
+### Example 4 - Find the path to the bicepconfig.json in use
+```powershell
+Get-BicepConfig -Path c:\bicepTemplates\storage.bicep
+```
+
+Returns the path to the bicepconfig.json in use and config
+
+## PARAMETERS
+
+### -Path
+Path to a bicep file
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Scope
+Scope of the config. `Local` returns the config in the current bicepconfig.json, `Merged` returns the merged config (local file and bicep default config), `Default` returns the default config.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+Accepted values: Local, Merged, Default
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS

--- a/Source/Bicep.psd1
+++ b/Source/Bicep.psd1
@@ -101,7 +101,8 @@ FunctionsToExport = @(
     'Publish-Bicep',
     'Restore-Bicep',
     'Find-BicepModule',
-    'Clear-BicepModuleCache'
+    'Clear-BicepModuleCache',
+    'Get-BicepConfig'
 )
 
 

--- a/Source/Public/Build-Bicep.ps1
+++ b/Source/Public/Build-Bicep.ps1
@@ -66,6 +66,8 @@ function Build-Bicep {
         if ($VerbosePreference -eq [System.Management.Automation.ActionPreference]::Continue) {
             $FullVersion = Get-BicepNetVersion -Verbose:$false
             Write-Verbose -Message "Using Bicep version: $FullVersion"
+            $BicepConfig= Get-BicepNetConfig -Path $Path
+            Write-Verbose -Message "Using Bicep Config: $BicepConfig.Path"
         }
     }
 

--- a/Source/Public/Build-Bicep.ps1
+++ b/Source/Public/Build-Bicep.ps1
@@ -66,8 +66,6 @@ function Build-Bicep {
         if ($VerbosePreference -eq [System.Management.Automation.ActionPreference]::Continue) {
             $FullVersion = Get-BicepNetVersion -Verbose:$false
             Write-Verbose -Message "Using Bicep version: $FullVersion"
-            $BicepConfig= Get-BicepNetConfig -Path $Path
-            Write-Verbose -Message "Using Bicep Config: $BicepConfig.Path"
         }
     }
 

--- a/Source/Public/Get-BicepConfig.ps1
+++ b/Source/Public/Get-BicepConfig.ps1
@@ -1,0 +1,37 @@
+function Get-BicepConfig {
+    [CmdletBinding()]
+    param (
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [ValidateScript( { Test-Path $_ })]
+        [string]$Path,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [ValidateSet("Local", "Merged", "Default")]
+        [string]$Scope
+
+    )
+    begin {
+        # Check if a newer version of the module is published
+        if (-not $Script:ModuleVersionChecked) {
+            TestModuleVersion
+        }       
+    }
+
+    process {        
+        
+        if ($Scope -eq 'Default' -and -not $path) {
+            Get-BicepNetConfig -Scope 'Default'
+        }
+        elseif ($Path) {
+            $BicepFile = Resolve-Path -Path $Path
+            if ($Scope) {
+                Get-BicepNetConfig -Path $BicepFile -Scope $Scope 
+            }
+            else {
+                Get-BicepNetConfig -Path $BicepFile
+            }
+        }
+    }
+}

--- a/Source/Public/Get-BicepConfig.ps1
+++ b/Source/Public/Get-BicepConfig.ps1
@@ -30,7 +30,14 @@ function Get-BicepConfig {
                 Get-BicepNetConfig -Path $BicepFile -Scope $Scope 
             }
             else {
-                Get-BicepNetConfig -Path $BicepFile
+                try {
+                    # Test if cusotm bicepconfig.json is present
+                    Get-BicepNetConfig -Path $BicepFile
+                }
+                catch {
+                    # Return default config if no custom bicepconfig.json is present
+                    Get-BicepNetConfig -Scope 'Default'
+                }
             }
         }
     }

--- a/Source/Public/Get-BicepConfig.ps1
+++ b/Source/Public/Get-BicepConfig.ps1
@@ -46,6 +46,7 @@ function Get-BicepConfig {
             Get-BicepNetConfig @Params -ErrorAction 'Stop'
         }
         catch [System.ArgumentException] {
+            # Failed to locate a bicepconfig, get the default config instead.
             Get-BicepNetConfig -Scope 'Default' -ErrorAction 'Stop'
         }
     }

--- a/Tests/Get-BicepConfig.Tests.ps1
+++ b/Tests/Get-BicepConfig.Tests.ps1
@@ -1,0 +1,132 @@
+BeforeAll {
+    $ScriptDirectory = Split-Path -Path $PSCommandPath -Parent
+    Import-Module -FullyQualifiedName "$ScriptDirectory\..\Source\Bicep.psd1" -ErrorAction Stop
+
+    
+}
+
+Describe 'Get-BicepConfig tests' {
+    BeforeAll {
+        $ScriptDirectory = Split-Path -Path $PSCommandPath -Parent
+        Copy-Item "$ScriptDirectory\supportFiles\*" -Destination TestDrive:\
+    }
+
+    Context 'Parameters' {
+        It 'Should have parameter Path' {
+                (Get-Command Get-BicepConfig).Parameters.Keys | Should -Contain 'Path'
+        }
+        It 'Should have parameter Scope' {
+                (Get-Command Get-BicepConfig).Parameters.Keys | Should -Contain 'Scope'
+        }
+    }
+
+    Context 'Get bicepconfig' {
+            
+        BeforeAll {
+            $localConfig = @'
+                    {
+                        "analyzers": {
+                            "core": {
+                                "verbose": false,
+                                "enabled": true,
+                                "rules": {
+                                    "no-unused-params": {
+                                        "level": "off"
+                                    }
+                                }
+                            }
+                        }
+                    }
+'@
+            $mergedConfig = @'
+                {
+                    "cloud": {
+                        "currentProfile": "AzureCloud",
+                        "profiles": {
+                            "AzureCloud": {
+                                "resourceManagerEndpoint": "https://management.azure.com",
+                                "activeDirectoryAuthority": "https://login.microsoftonline.com"
+                            },
+                            "AzureChinaCloud": {
+                                "resourceManagerEndpoint": "https://management.chinacloudapi.cn",
+                                "activeDirectoryAuthority": "https://login.chinacloudapi.cn"
+                            },
+                            "AzureUSGovernment": {
+                                "resourceManagerEndpoint": "https://management.usgovcloudapi.net",
+                                "activeDirectoryAuthority": "https://login.microsoftonline.us"
+                            }
+                        },
+                        "credentialPrecedence": [
+                            "AzureCLI",
+                            "AzurePowerShell"
+                        ]
+                    },
+                    "moduleAliases": {
+                        "ts": {},
+                        "br": {
+                            "public": {
+                                "registry": "mcr.microsoft.com",
+                                "modulePath": "bicep"
+                            }
+                        }
+                    },
+                    "analyzers": {
+                        "core": {
+                            "verbose": false,
+                            "enabled": true,
+                            "rules": {
+                                "no-hardcoded-env-urls": {
+                                    "level": "warning",
+                                    "disallowedhosts": [
+                                        "api.loganalytics.io",
+                                        "asazure.windows.net",
+                                        "azuredatalakeanalytics.net",
+                                        "azuredatalakestore.net",
+                                        "batch.core.windows.net",
+                                        "core.windows.net",
+                                        "database.windows.net",
+                                        "datalake.azure.net",
+                                        "gallery.azure.com",
+                                        "graph.windows.net",
+                                        "login.microsoftonline.com",
+                                        "management.azure.com",
+                                        "management.core.windows.net",
+                                        "region.asazure.windows.net",
+                                        "trafficmanager.net",
+                                        "vault.azure.net"
+                                    ],
+                                    "excludedhosts": [
+                                        "schema.management.azure.com"
+                                    ]
+                                },
+                                "no-unused-params": {
+                                    "level": "off"
+                                }
+                            }
+                        }
+                    }
+                }       
+'@
+        }
+            
+        It 'Get default config' {
+            $defaultConfig = Get-BicepConfig -Scope 'Default' 
+            $defaultConfig.Path | Should -Be 'Default'
+        }
+
+        It 'Get merged bicepconfig' {
+            $config = Get-BicepConfig -Path "$TestDrive\workingBicep.bicep" -Scope Merged
+            $mergedConfigTest = ConvertFrom-Json -InputObject $mergedConfig | ConvertTo-Json -Depth 10
+            $ConfigJson = ConvertFrom-Json -InputObject $config.Config | ConvertTo-Json -Depth 10
+            $ConfigJson | Should -BeExactly $mergedConfigTest
+        }
+
+        It 'Get local bicepconfig' {
+            $config = Get-BicepConfig -Path "$TestDrive\workingBicep.bicep" -Scope Local
+            $localConfigTest = ConvertFrom-Json -InputObject $localConfig | ConvertTo-Json -Depth 10
+            $ConfigJson = ConvertFrom-Json -InputObject $config.Config | ConvertTo-Json -Depth 10
+            $ConfigJson | Should -BeExactly $localConfigTest
+        }
+
+    }
+}


### PR DESCRIPTION
## Overview/Summary

Fixes #263

Added new command `Get-BicepConfig` that finds the `bicepconfig.json` file in use and the current configuration for bicep.

Example:
```powershell
#Get default config
$bicepConfig=Get-BicepConfig -Scope Default
$bicepConfig.Config

# Get merged config
$bicepConfig=Get-BicepConfig -Scope Merged -Path c:\bicepTemplates\storage.bicep
$bicepConfig.Config

# Find bicepconfig.json
Get-BicepConfig -Path c:\bicepTemplates\storage.bicep

```

## This PR fixes/adds/changes/removes

1. Adds new command `Get-BicepConfig`
2. Adds tests for `Get-BicepConfig`
3. Added command to manifest

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/PSBicep/PSBicep/pulls)
- [x] Associated it with relevant [issues](https://github.com/PSBicep/PSBicep/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/PSBicep/PSBicep/tree/main)
- [x] Performed testing.
- [x] Verified build scripts work.
- [x] Updated relevant and associated documentation.
