### PR TITLE
Added new command `Get-BicepMetadata`

### DIFF
--- a/Docs/Help/Get-BicepMetadata.md
+++ b/Docs/Help/Get-BicepMetadata.md
@@ -13,7 +13,7 @@ Get metadata from a Bicep template
 ## SYNTAX
 
 ```
-Get-BicepMetadata [-Path] <String> [[-OutputType] <String>] [-SkipGeneratorMeta] [<CommonParameters>]
+Get-BicepMetadata [-Path] <String> [[-OutputType] <String>] [-IncludeReservedMetadata] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -42,12 +42,12 @@ Get-BicepMetadata -Path .\myTemplate.bicep -OutputType Hashtable
 
 Get metadata from Bicep file and output as hashtable
 
-### Example 4 - Get metadata from Bicep file and skip _generator metadata
+### Example 4 - Get metadata from Bicep file and include reserved metadata
 ```powershell
-Get-BicepMetadata -Path .\myTemplate.bicep -SkipGeneratorMeta
+Get-BicepMetadata -Path .\myTemplate.bicep -IncludeReservedMetadata
 ```
 
-Get metadata from Bicep file and skip `_generator` metadata
+Get metadata from Bicep file and include Bicep reserved metadata
 
 ## PARAMETERS
 
@@ -82,8 +82,8 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -SkipGeneratorMeta
-Skip _generator metadata
+### -IncludeReservedMetadata
+Include Bicep reserved metadata
 
 ```yaml
 Type: SwitchParameter

--- a/Docs/Help/Get-BicepMetadata.md
+++ b/Docs/Help/Get-BicepMetadata.md
@@ -1,0 +1,112 @@
+---
+external help file: Bicep-help.xml
+Module Name: Bicep
+online version:
+schema: 2.0.0
+---
+
+# Get-BicepMetadata
+
+## SYNOPSIS
+Get metadata from a Bicep template
+
+## SYNTAX
+
+```
+Get-BicepMetadata [-Path] <String> [[-OutputType] <String>] [-SkipGeneratorMeta] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Get metadata from a Bicep template
+
+## EXAMPLES
+
+### Example 1 - Get metadata from Bicep file
+```powershell
+Get-BicepMetadata -Path .\myTemplate.bicep
+```
+
+Get metadata from Bicep file
+
+### Example 2 - Get metadata from Bicep file and output as Json
+```powershell
+Get-BicepMetadata -Path .\myTemplate.bicep -OutputType Json
+```
+
+Get metadata from Bicep file and output as json
+
+### Example 3 - Get metadata from Bicep file and output as hashtable
+```powershell
+Get-BicepMetadata -Path .\myTemplate.bicep -OutputType Hashtable
+```
+
+Get metadata from Bicep file and output as hashtable
+
+### Example 4 - Get metadata from Bicep file and skip _generator metadata
+```powershell
+Get-BicepMetadata -Path .\myTemplate.bicep -SkipGeneratorMeta
+```
+
+Get metadata from Bicep file and skip `_generator` metadata
+
+## PARAMETERS
+
+### -OutputType
+Specify output type
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+Accepted values: Simple, Json, Hashtable
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Path
+Path to Bicep file
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: PSPath
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SkipGeneratorMeta
+Skip _generator metadata
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS

--- a/Docs/Help/Get-BicepMetadata.md
+++ b/Docs/Help/Get-BicepMetadata.md
@@ -58,7 +58,7 @@ Specify output type
 Type: String
 Parameter Sets: (All)
 Aliases:
-Accepted values: Simple, Json, Hashtable
+Accepted values: PSObject, Json, Hashtable
 
 Required: False
 Position: 1

--- a/Source/Bicep.psd1
+++ b/Source/Bicep.psd1
@@ -102,7 +102,8 @@ FunctionsToExport = @(
     'Restore-Bicep',
     'Find-BicepModule',
     'Clear-BicepModuleCache',
-    'Get-BicepConfig'
+    'Get-BicepConfig',
+    'Get-BicepMetadata'
 )
 
 

--- a/Source/Public/Get-BicepMetadata.ps1
+++ b/Source/Public/Get-BicepMetadata.ps1
@@ -14,7 +14,9 @@ function Get-BicepMetadata {
         [Parameter()]
         [ValidateSet('Simple', 'Json', 'Hashtable')]
         [String]
-        $OutputType = 'Simple'
+        $OutputType = 'Simple',
+
+        [switch]$SkipGeneratorMeta
     )
     
     begin {
@@ -36,7 +38,11 @@ function Get-BicepMetadata {
 
             $ARMTemplate = $BuildResult[0]
             $ARMTemplateObject = ConvertFrom-Json -InputObject $ARMTemplate
-           
+            $templateMetadata=$ARMTemplateObject.metadata
+
+            if ($SkipGeneratorMeta.IsPresent) {
+                $templateMetadata.PSObject.Properties.Remove('_generator')
+            }
         }
         catch {
             # We don't care about errors here.

--- a/Source/Public/Get-BicepMetadata.ps1
+++ b/Source/Public/Get-BicepMetadata.ps1
@@ -12,9 +12,9 @@ function Get-BicepMetadata {
 
         # Set output type
         [Parameter()]
-        [ValidateSet('Simple', 'Json', 'Hashtable')]
+        [ValidateSet('PSObject', 'Json', 'Hashtable')]
         [String]
-        $OutputType = 'Simple',
+        $OutputType = 'PSObject',
 
         [switch]$SkipGeneratorMeta
     )
@@ -49,7 +49,7 @@ function Get-BicepMetadata {
         }        
 
         switch ($OutputType) {
-            'Simple' {
+            'PSObject' {
                 $ARMTemplateObject.metadata
             }
             'Json' {

--- a/Source/Public/Get-BicepMetadata.ps1
+++ b/Source/Public/Get-BicepMetadata.ps1
@@ -1,0 +1,57 @@
+function Get-BicepMetadata {
+    [CmdletBinding()]
+    param (
+        # Specifies a path to one or more locations.
+        [Parameter(
+            Mandatory = $true
+        )]
+        [Alias("PSPath")]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Path,
+
+        # Set output type
+        [Parameter()]
+        [ValidateSet('Simple', 'Json', 'Hashtable')]
+        [String]
+        $OutputType = 'Simple'
+    )
+    
+    begin {
+        if (-not $Script:ModuleVersionChecked) {
+            TestModuleVersion
+        }
+
+        if ($VerbosePreference -eq [System.Management.Automation.ActionPreference]::Continue) {
+            $FullVersion = Get-BicepNetVersion -Verbose:$false
+            Write-Verbose -Message "Using Bicep version: $FullVersion"
+        }
+    }
+    
+    process {
+        $file = Get-Item -Path $Path
+        try {  
+       
+            $BuildResult = Build-BicepNetFile -Path $file.FullName
+
+            $ARMTemplate = $BuildResult[0]
+            $ARMTemplateObject = ConvertFrom-Json -InputObject $ARMTemplate
+           
+        }
+        catch {
+            # We don't care about errors here.
+        }        
+
+        switch ($OutputType) {
+            'Simple' {
+                $ARMTemplateObject.metadata
+            }
+            'Json' {
+                $ARMTemplateObject.metadata | ConvertTo-Json
+            }
+            'Hashtable' {
+                $ARMTemplateObject.metadata | ConvertToHashtable -Ordered
+            }
+        }
+    }
+}

--- a/Source/Public/Get-BicepMetadata.ps1
+++ b/Source/Public/Get-BicepMetadata.ps1
@@ -16,7 +16,7 @@ function Get-BicepMetadata {
         [String]
         $OutputType = 'PSObject',
 
-        [switch]$SkipGeneratorMeta
+        [switch]$IncludeReservedMetadata
     )
     
     begin {
@@ -40,9 +40,9 @@ function Get-BicepMetadata {
             $ARMTemplateObject = ConvertFrom-Json -InputObject $ARMTemplate
             $templateMetadata=$ARMTemplateObject.metadata
 
-            if ($SkipGeneratorMeta.IsPresent) {
-                $templateMetadata.PSObject.Properties.Remove('_generator')
-            }
+            if (!$IncludeReservedMetadata.IsPresent) {
+                $templateMetadata=Select-Object -InputObject $templateMetadata -ExcludeProperty '_*'
+            } 
         }
         catch {
             # We don't care about errors here.
@@ -50,13 +50,13 @@ function Get-BicepMetadata {
 
         switch ($OutputType) {
             'PSObject' {
-                $ARMTemplateObject.metadata
+                $templateMetadata
             }
             'Json' {
-                $ARMTemplateObject.metadata | ConvertTo-Json
+                $templateMetadata | ConvertTo-Json
             }
             'Hashtable' {
-                $ARMTemplateObject.metadata | ConvertToHashtable -Ordered
+                $templateMetadata | ConvertToHashtable -Ordered
             }
         }
     }

--- a/Source/en-US/Bicep-help.xml
+++ b/Source/en-US/Bicep-help.xml
@@ -1982,9 +1982,9 @@ Convert-JsonToBicep -String $json</dev:code>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
-          <maml:name>SkipGeneratorMeta</maml:name>
+          <maml:name>IncludeReservedMetadata</maml:name>
           <maml:description>
-            <maml:para>Skip _generator metadata</maml:para>
+            <maml:para>Include Bicep reserved metadata</maml:para>
           </maml:description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -2020,9 +2020,9 @@ Convert-JsonToBicep -String $json</dev:code>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
-        <maml:name>SkipGeneratorMeta</maml:name>
+        <maml:name>IncludeReservedMetadata</maml:name>
         <maml:description>
-          <maml:para>Skip _generator metadata</maml:para>
+          <maml:para>Include Bicep reserved metadata</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
@@ -2080,10 +2080,10 @@ Convert-JsonToBicep -String $json</dev:code>
         </dev:remarks>
       </command:example>
       <command:example>
-        <maml:title>Example 4 - Get metadata from Bicep file and skip _generator metadata</maml:title>
-        <dev:code>Get-BicepMetadata -Path .\myTemplate.bicep -SkipGeneratorMeta</dev:code>
+        <maml:title>Example 4 - Get metadata from Bicep file and include reserved metadata</maml:title>
+        <dev:code>Get-BicepMetadata -Path .\myTemplate.bicep -IncludeReservedMetadata</dev:code>
         <dev:remarks>
-          <maml:para>Get metadata from Bicep file and skip `_generator` metadata</maml:para>
+          <maml:para>Get metadata from Bicep file and include Bicep reserved metadata</maml:para>
         </dev:remarks>
       </command:example>
     </command:examples>

--- a/Source/en-US/Bicep-help.xml
+++ b/Source/en-US/Bicep-help.xml
@@ -1970,7 +1970,7 @@ Convert-JsonToBicep -String $json</dev:code>
             <maml:para>Specify output type</maml:para>
           </maml:description>
           <command:parameterValueGroup>
-            <command:parameterValue required="false" command:variableLength="false">Simple</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">PSObject</command:parameterValue>
             <command:parameterValue required="false" command:variableLength="false">Json</command:parameterValue>
             <command:parameterValue required="false" command:variableLength="false">Hashtable</command:parameterValue>
           </command:parameterValueGroup>

--- a/Source/en-US/Bicep-help.xml
+++ b/Source/en-US/Bicep-help.xml
@@ -1939,6 +1939,158 @@ Convert-JsonToBicep -String $json</dev:code>
   </command:command>
   <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
     <command:details>
+      <command:name>Get-BicepMetadata</command:name>
+      <command:verb>Get</command:verb>
+      <command:noun>BicepMetadata</command:noun>
+      <maml:description>
+        <maml:para>Get metadata from a Bicep template</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Get metadata from a Bicep template</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Get-BicepMetadata</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="PSPath">
+          <maml:name>Path</maml:name>
+          <maml:description>
+            <maml:para>Path to Bicep file</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="none">
+          <maml:name>OutputType</maml:name>
+          <maml:description>
+            <maml:para>Specify output type</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">Simple</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Json</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Hashtable</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>SkipGeneratorMeta</maml:name>
+          <maml:description>
+            <maml:para>Skip _generator metadata</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="none">
+        <maml:name>OutputType</maml:name>
+        <maml:description>
+          <maml:para>Specify output type</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="PSPath">
+        <maml:name>Path</maml:name>
+        <maml:description>
+          <maml:para>Path to Bicep file</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>SkipGeneratorMeta</maml:name>
+        <maml:description>
+          <maml:para>Skip _generator metadata</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>System.Object</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>----------- Example 1 - Get metadata from Bicep file -----------</maml:title>
+        <dev:code>Get-BicepMetadata -Path .\myTemplate.bicep</dev:code>
+        <dev:remarks>
+          <maml:para>Get metadata from Bicep file</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>- Example 2 - Get metadata from Bicep file and output as Json -</maml:title>
+        <dev:code>Get-BicepMetadata -Path .\myTemplate.bicep -OutputType Json</dev:code>
+        <dev:remarks>
+          <maml:para>Get metadata from Bicep file and output as json</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>Example 3 - Get metadata from Bicep file and output as hashtable</maml:title>
+        <dev:code>Get-BicepMetadata -Path .\myTemplate.bicep -OutputType Hashtable</dev:code>
+        <dev:remarks>
+          <maml:para>Get metadata from Bicep file and output as hashtable</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>Example 4 - Get metadata from Bicep file and skip _generator metadata</maml:title>
+        <dev:code>Get-BicepMetadata -Path .\myTemplate.bicep -SkipGeneratorMeta</dev:code>
+        <dev:remarks>
+          <maml:para>Get metadata from Bicep file and skip `_generator` metadata</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
       <command:name>Get-BicepVersion</command:name>
       <command:verb>Get</command:verb>
       <command:noun>BicepVersion</command:noun>

--- a/Tests/Get-BicepMetadata.Tests.ps1
+++ b/Tests/Get-BicepMetadata.Tests.ps1
@@ -17,6 +17,9 @@ Describe 'Get-BicepMetadata tests' {
         It 'Should have parameter OutputType' {
                 (Get-Command Get-BicepMetadata).Parameters.Keys | Should -Contain 'OutputType'
         }
+        It 'Should have parameter IncludeReservedMetadata' {
+            (Get-Command Get-BicepMetadata).Parameters.Keys | Should -Contain 'IncludeReservedMetadata'
+    }
     }
 
     Context 'Get Bicep Metadata' {
@@ -46,15 +49,20 @@ Describe 'Get-BicepMetadata tests' {
         }
 
         It 'Returns json output' {
-            $meta = Get-BicepMetadata -Path "$TestDrive\supportFiles\bicepWithMeta.bicep" -OutputType Json -SkipGeneratorMeta
+            $meta = Get-BicepMetadata -Path "$TestDrive\supportFiles\bicepWithMeta.bicep" -OutputType Json
             $jsonMetaTest = ConvertFrom-Json -InputObject $jsonMeta | ConvertTo-Json -Depth 10
             $MetaJson = ConvertFrom-Json -InputObject $meta | ConvertTo-Json -Depth 10
             $MetaJson | Should -BeExactly $jsonMetaTest
         }
         
         It 'Returns hashtable output' {
-            $hashMetadata = Get-BicepMetadata -Path "$TestDrive\supportFiles\bicepWithMeta.bicep" -OutputType Hashtable -SkipGeneratorMeta
+            $hashMetadata = Get-BicepMetadata -Path "$TestDrive\supportFiles\bicepWithMeta.bicep" -OutputType Hashtable
             $hashMetadata.pesterMeta.author | Should -BeExactly $hashMeta.pesterMeta.author
+        }
+
+        It 'Returns reserved metadata' {
+            $hashMetadata = Get-BicepMetadata -Path "$TestDrive\supportFiles\bicepWithMeta.bicep" -IncludeReservedMetadata
+            $hashMetadata._generator | Should -Not -BeNullOrEmpty
         }
     }
 }

--- a/Tests/Get-BicepMetadata.Tests.ps1
+++ b/Tests/Get-BicepMetadata.Tests.ps1
@@ -1,0 +1,60 @@
+BeforeAll {
+    $ScriptDirectory = Split-Path -Path $PSCommandPath -Parent
+    Import-Module -FullyQualifiedName "$ScriptDirectory\..\Source\Bicep.psd1" -ErrorAction Stop
+}
+
+Describe 'Get-BicepMetadata tests' {
+    BeforeAll {
+        $ScriptDirectory = Split-Path -Path $PSCommandPath -Parent
+        $null = New-Item -ItemType 'Directory' -Path 'TestDrive:\supportFiles' -ErrorAction 'Ignore'
+        Copy-Item "$ScriptDirectory\supportFiles\*" -Destination 'TestDrive:\supportFiles'
+    }
+
+    Context 'Parameters' {
+        It 'Should have parameter Path' {
+                (Get-Command Get-BicepMetadata).Parameters.Keys | Should -Contain 'Path'
+        }
+        It 'Should have parameter OutputType' {
+                (Get-Command Get-BicepMetadata).Parameters.Keys | Should -Contain 'OutputType'
+        }
+    }
+
+    Context 'Get Bicep Metadata' {
+            
+        BeforeAll {
+            $jsonMeta = @'
+            {
+                "pesterMeta": {
+                    "author": "PSBicep",
+                    "version": "v1.0",
+                    "aNumber": 1
+                }
+            }
+'@
+            $hashMeta=@{
+                pesterMeta=@{
+                    author="PSBicep"
+                    version="v1.0"
+                    aNumber=1
+                }
+            }
+        }
+
+        It 'Returns default output when used without parameters' {
+            $defaultMetadata = Get-BicepMetadata -Path "$TestDrive\supportFiles\bicepWithMeta.bicep"
+            $defaultMetadata.pesterMeta.author | Should -BeExactly "PSBicep"
+        }
+
+        It 'Returns json output' {
+            $meta = Get-BicepMetadata -Path "$TestDrive\supportFiles\bicepWithMeta.bicep" -OutputType Json -SkipGeneratorMeta
+            $jsonMetaTest = ConvertFrom-Json -InputObject $jsonMeta | ConvertTo-Json -Depth 10
+            $MetaJson = ConvertFrom-Json -InputObject $meta | ConvertTo-Json -Depth 10
+            $MetaJson | Should -BeExactly $jsonMetaTest
+        }
+        
+        It 'Returns hashtable output' {
+            $hashMetadata = Get-BicepMetadata -Path "$TestDrive\supportFiles\bicepWithMeta.bicep" -OutputType Hashtable -SkipGeneratorMeta
+            $hashMetadata.pesterMeta.author | Should -BeExactly $hashMeta.pesterMeta.author
+        }
+    }
+}

--- a/Tests/supportFiles/bicepWithMeta.bicep
+++ b/Tests/supportFiles/bicepWithMeta.bicep
@@ -1,0 +1,5 @@
+metadata pesterMeta = {
+  author: 'PSBicep'
+  version: 'v1.0'
+  aNumber: 1
+}


### PR DESCRIPTION
## Overview/Summary

Fixes #277

Added new command to get Bicep metadata from templates

```powershell
# Get metadata from template as PS Object
Get-BicepMetadata -Path .\myTemplate.bicep

# Get metadata from template as json
Get-BicepMetadata -Path .\myTemplate.bicep -OutputType Json

# Get metadata from template as hashtable
Get-BicepMetadata -Path .\myTemplate.bicep -OutputType Hashtable

# Get metadata from template and include bicep reserved metadata
Get-BicepMetadata -Path .\myTemplate.bicep -IncludeReservedMetadata
```

## This PR fixes/adds/changes/removes

1. Added new commamd
2. Tests added

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/PSBicep/PSBicep/pulls)
- [x] Associated it with relevant [issues](https://github.com/PSBicep/PSBicep/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/PSBicep/PSBicep/tree/main)
- [x] Performed testing.
- [x] Verified build scripts work.
- [x] Updated relevant and associated documentation.
