### PR TITLE
Fix tests on WSL

### DIFF
--- a/Tests/Build-Bicep.Tests.ps1
+++ b/Tests/Build-Bicep.Tests.ps1
@@ -1,6 +1,6 @@
 BeforeAll {
     $ScriptDirectory = Split-Path -Path $PSCommandPath -Parent
-    Import-Module -FullyQualifiedName "$ScriptDirectory\..\Source\Bicep.psd1" -ErrorAction Stop
+    Import-Module -FullyQualifiedName (Join-Path $PSScriptRoot '..\Source\Bicep.psd1') -ErrorAction Stop
 
     $ScriptDirectory = Split-Path -Path $PSCommandPath -Parent
     Copy-Item "$ScriptDirectory\supportFiles\*" -Destination TestDrive:\

--- a/Tests/Build-Bicep.Tests.ps1
+++ b/Tests/Build-Bicep.Tests.ps1
@@ -1,9 +1,6 @@
 BeforeAll {
-    $ScriptDirectory = Split-Path -Path $PSCommandPath -Parent
-    Import-Module -FullyQualifiedName (Join-Path $PSScriptRoot '..\Source\Bicep.psd1') -ErrorAction Stop
-
-    $ScriptDirectory = Split-Path -Path $PSCommandPath -Parent
-    Copy-Item "$ScriptDirectory\supportFiles\*" -Destination TestDrive:\
+    Import-Module -FullyQualifiedName "$PSScriptRoot\..\Source\Bicep.psd1" -ErrorAction Stop
+    Copy-Item "$PSScriptRoot\supportFiles\*" -Destination TestDrive:\
 }
 
 Describe 'Build-Bicep' {

--- a/Tests/Clear-BicepModuleCache.Tests.ps1
+++ b/Tests/Clear-BicepModuleCache.Tests.ps1
@@ -1,6 +1,6 @@
 
 Remove-Module Bicep -ErrorAction SilentlyContinue
-Import-Module -FullyQualifiedName (Join-Path $PSScriptRoot '..\Source\Bicep.psd1') -ErrorAction Stop
+Import-Module -FullyQualifiedName "$PSScriptRoot\..\Source\Bicep.psd1" -ErrorAction Stop
 
 InModuleScope -ModuleName Bicep {
     Describe 'Clear-BicepModuleCache tests' {

--- a/Tests/Clear-BicepModuleCache.Tests.ps1
+++ b/Tests/Clear-BicepModuleCache.Tests.ps1
@@ -1,6 +1,6 @@
 
 Remove-Module Bicep -ErrorAction SilentlyContinue
-Import-Module $PSScriptRoot\..\Source\Bicep
+Import-Module -FullyQualifiedName (Join-Path $PSScriptRoot '..\Source\Bicep.psd1') -ErrorAction Stop
 
 InModuleScope -ModuleName Bicep {
     Describe 'Clear-BicepModuleCache tests' {

--- a/Tests/CompareBicepVersion.Tests.ps1
+++ b/Tests/CompareBicepVersion.Tests.ps1
@@ -1,6 +1,6 @@
 BeforeAll {
     $ScriptDirectory = Split-Path -Path $PSCommandPath -Parent
-    Import-Module -FullyQualifiedName "$ScriptDirectory\..\Source\Bicep.psd1" -ErrorAction Stop
+    Import-Module -FullyQualifiedName (Join-Path $PSScriptRoot '..\Source\Bicep.psd1') -ErrorAction Stop
 }
  
 Describe 'CompareBicepVersion' {

--- a/Tests/CompareBicepVersion.Tests.ps1
+++ b/Tests/CompareBicepVersion.Tests.ps1
@@ -1,6 +1,5 @@
 BeforeAll {
-    $ScriptDirectory = Split-Path -Path $PSCommandPath -Parent
-    Import-Module -FullyQualifiedName (Join-Path $PSScriptRoot '..\Source\Bicep.psd1') -ErrorAction Stop
+    Import-Module -FullyQualifiedName "$PSScriptRoot\..\Source\Bicep.psd1" -ErrorAction Stop
 }
  
 Describe 'CompareBicepVersion' {

--- a/Tests/Convert-JsonToBicep.Tests.ps1
+++ b/Tests/Convert-JsonToBicep.Tests.ps1
@@ -1,8 +1,6 @@
 BeforeAll {
-    $ScriptDirectory = Split-Path -Path $PSCommandPath -Parent
-    Import-Module -FullyQualifiedName (Join-Path $PSScriptRoot '..\Source\Bicep.psd1') -ErrorAction Stop
-
-    Copy-Item "$ScriptDirectory\supportFiles\*" -Destination TestDrive:\
+    Import-Module -FullyQualifiedName "$PSScriptRoot\..\Source\Bicep.psd1" -ErrorAction Stop
+    Copy-Item "$PSScriptRoot\supportFiles\*" -Destination TestDrive:\
 }
 
 InModuleScope -ModuleName Bicep {

--- a/Tests/Convert-JsonToBicep.Tests.ps1
+++ b/Tests/Convert-JsonToBicep.Tests.ps1
@@ -1,6 +1,6 @@
 BeforeAll {
     $ScriptDirectory = Split-Path -Path $PSCommandPath -Parent
-    Import-Module -FullyQualifiedName "$ScriptDirectory\..\Source\Bicep.psd1" -ErrorAction Stop
+    Import-Module -FullyQualifiedName (Join-Path $PSScriptRoot '..\Source\Bicep.psd1') -ErrorAction Stop
 
     Copy-Item "$ScriptDirectory\supportFiles\*" -Destination TestDrive:\
 }

--- a/Tests/ConvertTo-Bicep.Tests.ps1
+++ b/Tests/ConvertTo-Bicep.Tests.ps1
@@ -1,6 +1,6 @@
 BeforeAll {
     $ScriptDirectory = Split-Path -Path $PSCommandPath -Parent
-    Import-Module -FullyQualifiedName "$ScriptDirectory\..\Source\Bicep.psd1" -ErrorAction Stop
+    Import-Module -FullyQualifiedName (Join-Path $PSScriptRoot '..\Source\Bicep.psd1') -ErrorAction Stop
 
     $ScriptDirectory = Split-Path -Path $PSCommandPath -Parent
     Copy-Item "$ScriptDirectory\supportFiles\*" -Destination TestDrive:\

--- a/Tests/ConvertTo-Bicep.Tests.ps1
+++ b/Tests/ConvertTo-Bicep.Tests.ps1
@@ -1,9 +1,6 @@
 BeforeAll {
-    $ScriptDirectory = Split-Path -Path $PSCommandPath -Parent
-    Import-Module -FullyQualifiedName (Join-Path $PSScriptRoot '..\Source\Bicep.psd1') -ErrorAction Stop
-
-    $ScriptDirectory = Split-Path -Path $PSCommandPath -Parent
-    Copy-Item "$ScriptDirectory\supportFiles\*" -Destination TestDrive:\
+    Import-Module -FullyQualifiedName "$PSScriptRoot\..\Source\Bicep.psd1" -ErrorAction Stop
+    Copy-Item "$PSScriptRoot\supportFiles\*" -Destination TestDrive:\
 }
 
 Describe 'ConvertTo-Bicep' {

--- a/Tests/ConvertToHashTable.Tests.ps1
+++ b/Tests/ConvertToHashTable.Tests.ps1
@@ -1,6 +1,6 @@
 BeforeAll {
     $ScriptDirectory = Split-Path -Path $PSCommandPath -Parent
-    Import-Module -FullyQualifiedName "$ScriptDirectory\..\Source\Bicep.psd1" -ErrorAction Stop
+    Import-Module -FullyQualifiedName (Join-Path $PSScriptRoot '..\Source\Bicep.psd1') -ErrorAction Stop
 }
 
 Describe "ConvertToHashTable" {

--- a/Tests/ConvertToHashTable.Tests.ps1
+++ b/Tests/ConvertToHashTable.Tests.ps1
@@ -1,6 +1,5 @@
 BeforeAll {
-    $ScriptDirectory = Split-Path -Path $PSCommandPath -Parent
-    Import-Module -FullyQualifiedName (Join-Path $PSScriptRoot '..\Source\Bicep.psd1') -ErrorAction Stop
+    Import-Module -FullyQualifiedName "$PSScriptRoot\..\Source\Bicep.psd1" -ErrorAction Stop
 }
 
 Describe "ConvertToHashTable" {

--- a/Tests/Find-BicepModule.Tests.ps1
+++ b/Tests/Find-BicepModule.Tests.ps1
@@ -1,5 +1,5 @@
 Remove-Module Bicep -ErrorAction SilentlyContinue
-Import-Module $PSScriptRoot\..\Source\Bicep
+Import-Module -FullyQualifiedName (Join-Path $PSScriptRoot '..\Source\Bicep.psd1') -ErrorAction Stop
 
 InModuleScope -ModuleName Bicep {
     Describe 'Find-BicepModule tests' {

--- a/Tests/Find-BicepModule.Tests.ps1
+++ b/Tests/Find-BicepModule.Tests.ps1
@@ -1,5 +1,5 @@
 Remove-Module Bicep -ErrorAction SilentlyContinue
-Import-Module -FullyQualifiedName (Join-Path $PSScriptRoot '..\Source\Bicep.psd1') -ErrorAction Stop
+Import-Module -FullyQualifiedName "$PSScriptRoot\..\Source\Bicep.psd1" -ErrorAction Stop
 
 InModuleScope -ModuleName Bicep {
     Describe 'Find-BicepModule tests' {

--- a/Tests/Get-BicepApiReference.Tests.ps1
+++ b/Tests/Get-BicepApiReference.Tests.ps1
@@ -1,7 +1,6 @@
 BeforeAll {
-    $ScriptDirectory = Split-Path -Path $PSCommandPath -Parent
     # We have to import the module with -Force to get it to load bicep types properly.
-    Import-Module -FullyQualifiedName "$ScriptDirectory\..\Source\Bicep.psd1" -Force -ErrorAction Stop 
+    Import-Module -FullyQualifiedName "$PSScriptRoot\..\Source\Bicep.psd1" -Force -ErrorAction Stop
 }
 
 Describe "Get-BicepApiReference" {

--- a/Tests/Get-BicepConfig.Tests.ps1
+++ b/Tests/Get-BicepConfig.Tests.ps1
@@ -1,8 +1,6 @@
 BeforeAll {
     $ScriptDirectory = Split-Path -Path $PSCommandPath -Parent
-    Import-Module -FullyQualifiedName "$ScriptDirectory\..\Source\Bicep.psd1" -ErrorAction Stop
-
-    
+    Import-Module -FullyQualifiedName (Join-Path $PSScriptRoot '..\Source\Bicep.psd1') -ErrorAction Stop
 }
 
 Describe 'Get-BicepConfig tests' {
@@ -166,7 +164,7 @@ Describe 'Get-BicepConfig tests' {
         AfterAll {
             # Bicep doesnt seem to properly release the config file, let's wait for it.
             $configFileLocked = $true
-            $configFilePath = "$TestDrive\supportFiles\bicepconfig.json"
+            $configFilePath = Join-Path $TestDrive 'supportFiles\bicepconfig.json'
             while($configFileLocked) {
                 try {
                     $configFile = [System.IO.File]::Open($configFilePath, 'Open', 'Read')

--- a/Tests/Get-BicepConfig.Tests.ps1
+++ b/Tests/Get-BicepConfig.Tests.ps1
@@ -1,6 +1,5 @@
 BeforeAll {
-    $ScriptDirectory = Split-Path -Path $PSCommandPath -Parent
-    Import-Module -FullyQualifiedName (Join-Path $PSScriptRoot '..\Source\Bicep.psd1') -ErrorAction Stop
+    Import-Module -FullyQualifiedName "$PSScriptRoot\..\Source\Bicep.psd1" -ErrorAction Stop
 }
 
 Describe 'Get-BicepConfig tests' {

--- a/Tests/Get-BicepMetadata.Tests.ps1
+++ b/Tests/Get-BicepMetadata.Tests.ps1
@@ -1,13 +1,11 @@
 BeforeAll {
-    $ScriptDirectory = Split-Path -Path $PSCommandPath -Parent
-    Import-Module -FullyQualifiedName (Join-Path $PSScriptRoot '..\Source\Bicep.psd1') -ErrorAction Stop
+    Import-Module -FullyQualifiedName "$PSScriptRoot\..\Source\Bicep.psd1" -ErrorAction Stop
 }
 
 Describe 'Get-BicepMetadata tests' {
     BeforeAll {
-        $ScriptDirectory = Split-Path -Path $PSCommandPath -Parent
         $null = New-Item -ItemType 'Directory' -Path 'TestDrive:\supportFiles' -ErrorAction 'Ignore'
-        Copy-Item "$ScriptDirectory\supportFiles\*" -Destination 'TestDrive:\supportFiles'
+        Copy-Item "$PSScriptRoot\supportFiles\*" -Destination 'TestDrive:\supportFiles'
     }
 
     Context 'Parameters' {

--- a/Tests/Get-BicepMetadata.Tests.ps1
+++ b/Tests/Get-BicepMetadata.Tests.ps1
@@ -1,6 +1,6 @@
 BeforeAll {
     $ScriptDirectory = Split-Path -Path $PSCommandPath -Parent
-    Import-Module -FullyQualifiedName "$ScriptDirectory\..\Source\Bicep.psd1" -ErrorAction Stop
+    Import-Module -FullyQualifiedName (Join-Path $PSScriptRoot '..\Source\Bicep.psd1') -ErrorAction Stop
 }
 
 Describe 'Get-BicepMetadata tests' {

--- a/Tests/Get-BicepVersion.Tests.ps1
+++ b/Tests/Get-BicepVersion.Tests.ps1
@@ -1,6 +1,5 @@
 BeforeAll {
-    $ScriptDirectory = Split-Path -Path $PSCommandPath -Parent
-    Import-Module -FullyQualifiedName (Join-Path $PSScriptRoot '..\Source\Bicep.psd1') -ErrorAction Stop
+    Import-Module -FullyQualifiedName "$PSScriptRoot\..\Source\Bicep.psd1" -ErrorAction Stop
 }
 
 Describe 'Get-BicepVersion' {

--- a/Tests/Get-BicepVersion.Tests.ps1
+++ b/Tests/Get-BicepVersion.Tests.ps1
@@ -1,6 +1,6 @@
 BeforeAll {
     $ScriptDirectory = Split-Path -Path $PSCommandPath -Parent
-    Import-Module -FullyQualifiedName "$ScriptDirectory\..\Source\Bicep.psd1" -ErrorAction Stop
+    Import-Module -FullyQualifiedName (Join-Path $PSScriptRoot '..\Source\Bicep.psd1') -ErrorAction Stop
 }
 
 Describe 'Get-BicepVersion' {

--- a/Tests/InstalledBicepVersion.Tests.ps1
+++ b/Tests/InstalledBicepVersion.Tests.ps1
@@ -1,8 +1,5 @@
-
-
 BeforeAll {
-    $ScriptDirectory = Split-Path -Path $PSCommandPath -Parent
-    Import-Module -FullyQualifiedName (Join-Path $PSScriptRoot '..\Source\Bicep.psd1') -ErrorAction Stop
+    Import-Module -FullyQualifiedName "$PSScriptRoot\..\Source\Bicep.psd1" -ErrorAction Stop
 }
 
 Describe 'InstalledBicepVersion' {

--- a/Tests/InstalledBicepVersion.Tests.ps1
+++ b/Tests/InstalledBicepVersion.Tests.ps1
@@ -2,7 +2,7 @@
 
 BeforeAll {
     $ScriptDirectory = Split-Path -Path $PSCommandPath -Parent
-    Import-Module -FullyQualifiedName "$ScriptDirectory\..\Source\Bicep.psd1" -ErrorAction Stop
+    Import-Module -FullyQualifiedName (Join-Path $PSScriptRoot '..\Source\Bicep.psd1') -ErrorAction Stop
 }
 
 Describe 'InstalledBicepVersion' {

--- a/Tests/ListBicepVersions.Tests.ps1
+++ b/Tests/ListBicepVersions.Tests.ps1
@@ -1,7 +1,6 @@
 
 BeforeAll {
-    $ScriptDirectory = Split-Path -Path $PSCommandPath -Parent
-    Import-Module -FullyQualifiedName (Join-Path $PSScriptRoot '..\Source\Bicep.psd1') -ErrorAction Stop
+    Import-Module -FullyQualifiedName "$PSScriptRoot\..\Source\Bicep.psd1" -ErrorAction Stop
 }
 
 Describe 'ListBicepVersions' {

--- a/Tests/ListBicepVersions.Tests.ps1
+++ b/Tests/ListBicepVersions.Tests.ps1
@@ -1,7 +1,7 @@
 
 BeforeAll {
     $ScriptDirectory = Split-Path -Path $PSCommandPath -Parent
-    Import-Module -FullyQualifiedName "$ScriptDirectory\..\Source\Bicep.psd1" -ErrorAction Stop
+    Import-Module -FullyQualifiedName (Join-Path $PSScriptRoot '..\Source\Bicep.psd1') -ErrorAction Stop
 }
 
 Describe 'ListBicepVersions' {

--- a/Tests/Module.tests.ps1
+++ b/Tests/Module.tests.ps1
@@ -4,15 +4,14 @@
 #>
 
 #region Set up test cases
-$ScriptDirectory = Split-Path -Path $PSCommandPath -Parent
 
 # actual exported functions
-$ExportedFunctions = (Get-Module -FullyQualifiedName "$ScriptDirectory\..\Source\Bicep.psd1" -ListAvailable -Refresh).ExportedFunctions.Keys
-$ModuleName = (Get-ChildItem -Path "$ScriptDirectory\..\Source\Bicep.psm1").BaseName
+$ExportedFunctions = (Get-Module -FullyQualifiedName "$PSScriptRoot\..\Source\Bicep.psd1" -ListAvailable -Refresh).ExportedFunctions.Keys
+$ModuleName = (Get-ChildItem -Path "$PSScriptRoot\..\Source\Bicep.psm1").BaseName
 
 # Create test cases for public functions
-if (Test-Path -Path "$ScriptDirectory\..\Source\Public" -PathType Container) {
-    $PublicFiles = Get-Childitem "$ScriptDirectory\..\Source\Public\*.ps1"
+if (Test-Path -Path "$PSScriptRoot\..\Source\Public" -PathType Container) {
+    $PublicFiles = Get-Childitem "$PSScriptRoot\..\Source\Public\*.ps1"
     $PublicFunctions = $PublicFiles.Name -replace '\.ps1$'
 
     $PublicTestCases = @()
@@ -25,8 +24,8 @@ if (Test-Path -Path "$ScriptDirectory\..\Source\Public" -PathType Container) {
 }
 
 # Create test cases for private functions
-if (Test-Path -Path "$ScriptDirectory\..\Source\Private" -PathType Container) {
-    $PrivateFiles = Get-Childitem "$ScriptDirectory\..\Source\Private\*.ps1"
+if (Test-Path -Path "$PSScriptRoot\..\Source\Private" -PathType Container) {
+    $PrivateFiles = Get-Childitem "$PSScriptRoot\..\Source\Private\*.ps1"
     $PrivateFunctions = $PrivateFiles.Name -replace '\.ps1$'
 
     $PrivateTestCases = @()
@@ -40,8 +39,7 @@ if (Test-Path -Path "$ScriptDirectory\..\Source\Private" -PathType Container) {
 
 # Import the module files before starting tests
 BeforeAll {
-    $ScriptDirectory = Split-Path -Path $PSCommandPath -Parent
-    Import-Module -FullyQualifiedName (Join-Path $PSScriptRoot '..\Source\Bicep.psd1') -ErrorAction Stop
+    Import-Module -FullyQualifiedName "$PSScriptRoot\..\Source\Bicep.psd1" -ErrorAction Stop
 }
 
 Describe "Module $ModuleName" {

--- a/Tests/Module.tests.ps1
+++ b/Tests/Module.tests.ps1
@@ -41,7 +41,7 @@ if (Test-Path -Path "$ScriptDirectory\..\Source\Private" -PathType Container) {
 # Import the module files before starting tests
 BeforeAll {
     $ScriptDirectory = Split-Path -Path $PSCommandPath -Parent
-    Import-Module -FullyQualifiedName "$ScriptDirectory\..\Source\Bicep.psd1" -ErrorAction Stop
+    Import-Module -FullyQualifiedName (Join-Path $PSScriptRoot '..\Source\Bicep.psd1') -ErrorAction Stop
 }
 
 Describe "Module $ModuleName" {

--- a/Tests/New-BicepParameterFile.Tests.ps1
+++ b/Tests/New-BicepParameterFile.Tests.ps1
@@ -1,9 +1,6 @@
 BeforeAll {
-    $ScriptDirectory = Split-Path -Path $PSCommandPath -Parent
-    Import-Module -FullyQualifiedName (Join-Path $PSScriptRoot '..\Source\Bicep.psd1') -ErrorAction Stop
-
-    $ScriptDirectory = Split-Path -Path $PSCommandPath -Parent
-    Copy-Item "$ScriptDirectory\supportFiles\*" -Destination TestDrive:\
+    Import-Module -FullyQualifiedName "$PSScriptRoot\..\Source\Bicep.psd1" -ErrorAction Stop
+    Copy-Item "$PSScriptRoot\supportFiles\*" -Destination TestDrive:\
 }
 
 Describe 'New-BicepParameterFile' {

--- a/Tests/New-BicepParameterFile.Tests.ps1
+++ b/Tests/New-BicepParameterFile.Tests.ps1
@@ -1,6 +1,6 @@
 BeforeAll {
     $ScriptDirectory = Split-Path -Path $PSCommandPath -Parent
-    Import-Module -FullyQualifiedName "$ScriptDirectory\..\Source\Bicep.psd1" -ErrorAction Stop
+    Import-Module -FullyQualifiedName (Join-Path $PSScriptRoot '..\Source\Bicep.psd1') -ErrorAction Stop
 
     $ScriptDirectory = Split-Path -Path $PSCommandPath -Parent
     Copy-Item "$ScriptDirectory\supportFiles\*" -Destination TestDrive:\

--- a/Tests/Publish-Bicep.Tests.ps1
+++ b/Tests/Publish-Bicep.Tests.ps1
@@ -1,12 +1,7 @@
 BeforeAll {
-    $ScriptDirectory = Split-Path -Path $PSCommandPath -Parent
-    Import-Module -FullyQualifiedName "$ScriptDirectory\..\Source\BicepNet.PS\BicepNet.PS.psd1" -ErrorAction Stop
-
-    $ScriptDirectory = Split-Path -Path $PSCommandPath -Parent
-    Import-Module -FullyQualifiedName (Join-Path $PSScriptRoot '..\Source\Bicep.psd1') -ErrorAction Stop
-
-    $ScriptDirectory = Split-Path -Path $PSCommandPath -Parent
-    Copy-Item "$ScriptDirectory\supportFiles\*" -Destination TestDrive:\
+    Import-Module -FullyQualifiedName "$PSScriptRoot\..\Source\BicepNet.PS\BicepNet.PS.psd1" -ErrorAction Stop
+    Import-Module -FullyQualifiedName "$PSScriptRoot\..\Source\Bicep.psd1" -ErrorAction Stop
+    Copy-Item "$PSScriptRoot\supportFiles\*" -Destination TestDrive:\
 }
 
 Describe 'Publish-Bicep' {

--- a/Tests/Publish-Bicep.Tests.ps1
+++ b/Tests/Publish-Bicep.Tests.ps1
@@ -3,7 +3,7 @@ BeforeAll {
     Import-Module -FullyQualifiedName "$ScriptDirectory\..\Source\BicepNet.PS\BicepNet.PS.psd1" -ErrorAction Stop
 
     $ScriptDirectory = Split-Path -Path $PSCommandPath -Parent
-    Import-Module -FullyQualifiedName "$ScriptDirectory\..\Source\Bicep.psd1" -ErrorAction Stop
+    Import-Module -FullyQualifiedName (Join-Path $PSScriptRoot '..\Source\Bicep.psd1') -ErrorAction Stop
 
     $ScriptDirectory = Split-Path -Path $PSCommandPath -Parent
     Copy-Item "$ScriptDirectory\supportFiles\*" -Destination TestDrive:\

--- a/Tests/Restore-Bicep.Tests.ps1
+++ b/Tests/Restore-Bicep.Tests.ps1
@@ -1,9 +1,6 @@
 BeforeAll {
-    $ScriptDirectory = Split-Path -Path $PSCommandPath -Parent
-    Import-Module -FullyQualifiedName (Join-Path $PSScriptRoot '..\Source\Bicep.psd1') -ErrorAction Stop
-
-    $ScriptDirectory = Split-Path -Path $PSCommandPath -Parent
-    Copy-Item "$ScriptDirectory\supportFiles\*" -Destination TestDrive:\
+    Import-Module -FullyQualifiedName "$PSScriptRoot\..\Source\Bicep.psd1" -ErrorAction Stop
+    Copy-Item "$PSScriptRoot\supportFiles\*" -Destination TestDrive:\
 }
 
 Describe 'Restore-Bicep' {

--- a/Tests/Restore-Bicep.Tests.ps1
+++ b/Tests/Restore-Bicep.Tests.ps1
@@ -1,6 +1,6 @@
 BeforeAll {
     $ScriptDirectory = Split-Path -Path $PSCommandPath -Parent
-    Import-Module -FullyQualifiedName "$ScriptDirectory\..\Source\Bicep.psd1" -ErrorAction Stop
+    Import-Module -FullyQualifiedName (Join-Path $PSScriptRoot '..\Source\Bicep.psd1') -ErrorAction Stop
 
     $ScriptDirectory = Split-Path -Path $PSCommandPath -Parent
     Copy-Item "$ScriptDirectory\supportFiles\*" -Destination TestDrive:\

--- a/Tests/TestBicep.Tests.ps1
+++ b/Tests/TestBicep.Tests.ps1
@@ -1,6 +1,6 @@
 BeforeAll {
     $ScriptDirectory = Split-Path -Path $PSCommandPath -Parent
-    Import-Module -FullyQualifiedName "$ScriptDirectory\..\Source\Bicep.psd1" -ErrorAction Stop
+    Import-Module -FullyQualifiedName (Join-Path $PSScriptRoot '..\Source\Bicep.psd1') -ErrorAction Stop
 }
 
 Describe "TestBicep" {

--- a/Tests/TestBicep.Tests.ps1
+++ b/Tests/TestBicep.Tests.ps1
@@ -1,6 +1,5 @@
 BeforeAll {
-    $ScriptDirectory = Split-Path -Path $PSCommandPath -Parent
-    Import-Module -FullyQualifiedName (Join-Path $PSScriptRoot '..\Source\Bicep.psd1') -ErrorAction Stop
+    Import-Module -FullyQualifiedName "$PSScriptRoot\..\Source\Bicep.psd1" -ErrorAction Stop
 }
 
 Describe "TestBicep" {

--- a/Tests/Update-BicepTypes.Tests.ps1
+++ b/Tests/Update-BicepTypes.Tests.ps1
@@ -1,6 +1,6 @@
 BeforeAll {
     $ScriptDirectory = Split-Path -Path $PSCommandPath -Parent
-    Import-Module -FullyQualifiedName "$ScriptDirectory\..\Source\Bicep.psd1" -ErrorAction Stop
+    Import-Module -FullyQualifiedName (Join-Path $PSScriptRoot '..\Source\Bicep.psd1') -ErrorAction Stop
     New-Item -Path 'TestDrive:\' -Name 'Assets' -ItemType Directory
 }
 


### PR DESCRIPTION
# Overview/Summary

Fixes #289 

1. Add a Join-Path where there's a filepath resolution in tests - this should allow both Windows and Linux (in my case WSL) to work
2. A couple of tests had an invalid path to the module psd1

Tests pass on my WSL machine:

<img width="467" alt="image" src="https://github.com/PSBicep/PSBicep/assets/62133917/fe427be3-bb96-4268-8f10-e162304e0a72">


## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/PSBicep/PSBicep/pulls)
- [x] Associated it with relevant [issues](https://github.com/PSBicep/PSBicep/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/PSBicep/PSBicep/tree/main)
- [x] Performed testing.
- [ ] Verified build scripts work.
- [ ] Updated relevant and associated documentation.
