### PR TITLE
Bicep v0.24.24 Support

### DIFF
--- a/Docs/bicep-version-comparison.md
+++ b/Docs/bicep-version-comparison.md
@@ -6,6 +6,9 @@ The table below shows which version of the Bicep assemblies and BicepNet that ar
 
 | Bicep PowerShell version | Bicep assembly version | BicepNet Version |
 | --- | --- | -- |
+| `2.5.1` | `0.24.24` | `2.3.1` |
+| `2.5.0-preview0001` | `0.20.4` | `2.2.1` |
+| `2.4.0` | `0.20.4` | `2.2.1` |
 | `2.4.0-Preview1` | `0.18.4` | `2.1.1` |
 | `2.3.3` | `0.11.1` | `2.0.10` |
 | `2.3.2` | `0.10.61` | `2.0.9` |

--- a/README.md
+++ b/README.md
@@ -47,8 +47,6 @@ Install-Module -Name Bicep
 
 ### Pre-release versions
 
->**Note:** Running the preview version requires at least PowerShell version 7.3! If you are running this in a pipeline, use the [PWSHUpdater GitHub action](https://github.com/marketplace/actions/pwshupdater) or the [PowerShell updater Azure DevOps task](https://marketplace.visualstudio.com/items?itemName=Bjompen.PWSHUpdater) to run.
-
 To install the latest version in development use the `-AllowPrerelease` switch.
 
 ```powershell
@@ -78,8 +76,8 @@ This project is currently maintained by the following coders:
 
 <!-- References -->
 [BicepIcon]: logo/BicePS_40px.png
-[Bicep]: https://img.shields.io/badge/Bicep-v2.3.3-blue
-[BicepPreview]: https://img.shields.io/badge/Bicep-v2.4.0--Preview1-red
+[Bicep]: https://img.shields.io/badge/Bicep-v2.4.0-blue
+[BicepPreview]: https://img.shields.io/badge/Bicep-v2.5.0--Preview1-red
 [BicepDownloads]: https://img.shields.io/powershellgallery/dt/Bicep
 [BicepGallery]: https://www.powershellgallery.com/packages/Bicep/
-[BicepGalleryPreview]: https://www.powershellgallery.com/packages/Bicep/2.4.0-Preview1
+[BicepGalleryPreview]: https://www.powershellgallery.com/packages/Bicep/2.5.0-Preview1

--- a/RequiredModules.psd1
+++ b/RequiredModules.psd1
@@ -15,7 +15,7 @@
     Sampler                       = 'latest'
     'Sampler.GitHubTasks'         = 'latest'
     MarkdownLinkCheck             = 'latest'
-    'BicepNet.PS'                 = '2.2.1'
+    'BicepNet.PS'                 = '2.3.1'
     'SimonWahlin/platyPS' = @{
         Version = 'main'
         DependencyType = 'GitHub'


### PR DESCRIPTION
## Overview/Summary

Upgrades BicepNet.PS version to 2.3.1 (with Bicep support for v0.24.24, bumps PSBicep version to 2.5.1.

Replace this with a brief description of what this Pull Request fixes, changes, etc.

## This PR fixes/adds/changes/removes

1. Upgrades BicepNet to 2.3.1 with Bicep support for v0.24.24.
2. Bumps PSBicep version to 2.5.1.
3. Updates readme with newer versions.
4. Removes section on pre-release on runners.
