### PR TITLE
Fixes broken `Build-Bicep` test

### DIFF
--- a/Tests/Build-Bicep.Tests.ps1
+++ b/Tests/Build-Bicep.Tests.ps1
@@ -1,5 +1,6 @@
 BeforeAll {
-    Import-Module -FullyQualifiedName "$PSScriptRoot\..\Source\BicepNet.PS" -ErrorAction Stop
+    Import-Module -FullyQualifiedName "$PSScriptRoot\..\Source\Bicep.psd1" -ErrorAction Stop
+    Copy-Item "$PSScriptRoot\supportFiles\*" -Destination TestDrive:\
 }
 
 Describe 'Build-Bicep' {


### PR DESCRIPTION
## Overview/Summary

Fixes the broken test for `Build-Bicep` after #293, somehow it made it through. I thought I adjusted it pre-merge.

## This PR fixes/adds/changes/removes

1. Changes the module loading back in the test for `Build-Bicep`
