### PR TITLE
Fixes release workflow to load latest PowerShellForGitHub version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,7 +109,7 @@ jobs:
 
     - name: Publish Release
       shell: pwsh
-      run: Import-Module ./output/RequiredModules/PowerShellForGitHub/0.16.1/PowerShellForGitHub.psd1 ; ./build.ps1 -tasks publish
+      run: Import-Module ./output/RequiredModules/PowerShellForGitHub; ./build.ps1 -tasks publish
       env:
         GitHubToken: ${{ secrets.GITHUB_TOKEN }}
         GalleryApiToken: ${{ secrets.BICEP_PSGALLERY_KEY }}


### PR DESCRIPTION
# Contributing a Pull Request

## Overview/Summary

Fixes the release workflow which currently is broken because it depends on a specific version of a module which is downloaded as `latest` and has been updated since we built the workflow.

The module is now loaded regardless of version.

## This PR fixes

1. The broken release step at the end of the workflow.

## As part of this Pull Request I have

- [X] Checked for duplicate [Pull Requests](https://github.com/PSBicep/PSBicep/pulls)
- [ ] Associated it with relevant [issues](https://github.com/PSBicep/PSBicep/issues), for tracking and closure.
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/PSBicep/PSBicep/tree/main)
- [X] Performed testing.
- [X] Verified build scripts work.
- [ ] Updated relevant and associated documentation.
