### PR TITLE
Configuration for `gitversion` for `main` instead of `master`

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -6,7 +6,7 @@ patch-version-bump-message: '\s?(fix|patch)'
 no-bump-message: '\+semver:\s?(none|skip)'
 assembly-informational-format: '{NuGetVersionV2}+Sha.{Sha}.Date.{CommitDate}'
 branches:
-  master:
+  main:
     tag: preview
     regex: ^main$
   pull-request:
@@ -15,26 +15,15 @@ branches:
     tag: useBranchName
     increment: Minor
     regex: f(eature(s)?)?[\/-]
-    source-branches: ['master']
+    source-branches: ['main']
   hotfix:
     tag: fix
     increment: Patch
     regex: (hot)?fix(es)?[\/-]
-    source-branches: ['master']
+    source-branches: ['main']
 
 ignore:
   sha: []
 merge-message-formats: {}
 
-
-# feature:
-#   tag: useBranchName
-#   increment: Minor
-#   regex: f(eature(s)?)?[/-]
-#   source-branches: ['master']
-# hotfix:
-#   tag: fix
-#   increment: Patch
-#   regex: (hot)?fix(es)?[/-]
-#   source-branches: ['master']
-
+tag-prefix: '[vV]'


### PR DESCRIPTION
# Contributing a Pull Request

## Overview/Summary

The configuration for `gitversion` pointed to master instead of main, which is why the recent release workflow failed. This PR changes the configuration to use the main branch instead.

## As part of this Pull Request I have

- [X] Checked for duplicate [Pull Requests](https://github.com/PSBicep/PSBicep/pulls)
- [ ] Associated it with relevant [issues](https://github.com/PSBicep/PSBicep/issues), for tracking and closure.
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/PSBicep/PSBicep/tree/main)
- [X] Performed testing.
- [X] Verified build scripts work.