### PR TITLE
Updated semver variable for gitversion

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -38,7 +38,7 @@ runs:
     shell: pwsh
     run: ./build.ps1 -tasks pack
     env:
-      ModuleVersion: ${{ env.gitversion.outputs.SemVer }}
+      ModuleVersion: ${{ env.gitversion.outputs.semVer }}
 
   - name: Publish build artifacts
     uses: actions/upload-artifact@v3

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -38,7 +38,7 @@ runs:
     shell: pwsh
     run: ./build.ps1 -tasks pack
     env:
-      ModuleVersion: ${{ env.gitVersion.SemVer }}
+      ModuleVersion: ${{ env.gitversion.outputs.SemVer }}
 
   - name: Publish build artifacts
     uses: actions/upload-artifact@v3

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -38,7 +38,7 @@ runs:
     shell: pwsh
     run: ./build.ps1 -tasks pack
     env:
-      ModuleVersion: ${{ env.gitversion.outputs.semVer }}
+      ModuleVersion: ${{ steps.gitversion.outputs.semVer }}
 
   - name: Publish build artifacts
     uses: actions/upload-artifact@v3


### PR DESCRIPTION
Updated variable for GitVersion in build action to ensure that the correct version is picked up.

This broke in #343 when configuration changed for GitVersion version 6.

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/PSBicep/PSBicep/pulls)
- [x] Associated it with relevant [issues](https://github.com/PSBicep/PSBicep/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/PSBicep/PSBicep/tree/main)
- [x] Performed testing.
- [x] Verified build scripts work.
- [x] Updated relevant and associated documentation.
