### PR TITLE
Debugging support for ALC with VS Code tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 output/
-.vscode
 tmp/
 bin/
 obj/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,33 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug PSBicep",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            "program": "pwsh",
+            "args": [
+                "-NoExit",
+                "-NoProfile",
+                "-Command",
+                "Import-Module ${workspaceFolder}/output/Bicep -Verbose",
+            ],
+            "cwd": "${workspaceFolder}",
+            "stopAtEntry": false,
+            "console": "integratedTerminal",
+            "justMyCode": false,
+            "requireExactSource": false
+        },
+        {
+          "name": "PowerShell: Binary Module Interactive Session",
+          "type": "PowerShell",
+          "request": "launch",
+          "createTemporaryIntegratedConsole": true,
+          "attachDotnetDebugger": true,
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,23 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "${workspaceFolder}/build.ps1",
+            "type": "shell",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "args": [
+                "build",
+            ],
+            "presentation": {
+                "reveal": "always"
+            },
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/PSBicep.Core/PSBicep.Core.csproj
+++ b/PSBicep.Core/PSBicep.Core.csproj
@@ -5,6 +5,8 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <PackageIcon>BicePS_40px.png</PackageIcon>
+    <DebugType>embedded</DebugType>
+    <EmbedAllSources>true</EmbedAllSources>
   </PropertyGroup>
 
   <ItemGroup>

--- a/PSBicep/PSBicep.csproj
+++ b/PSBicep/PSBicep.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
+    <DebugType>embedded</DebugType>
+    <EmbedAllSources>true</EmbedAllSources>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# Contributing a Pull Request

## Overview/Summary

This PR adds support for debugging the module including the core module loaded in a separate AssemblyLoadContext, by embedding the symbols inside the DLL.

This will not affect the total size of the module, only move the .pdb files into the .dll files. The impact on performance is insignificant.

It also adds a task to VS Code to support debugging.

Image below shows a breakpoint hit inside the PSBicep.Core project, loaded in a separate ALC.

![image](https://github.com/user-attachments/assets/d437aab2-d80f-4880-87cc-ab2ad7cfdec5)

## As part of this Pull Request I have

- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/PSBicep/PSBicep/tree/main)
- [x] Performed testing.
- [x] Verified build scripts work.