### PR TITLE
Fix #364 by implementing a singleton of the BicepService

### DIFF
--- a/PSBicep.Core/BicepService.cs
+++ b/PSBicep.Core/BicepService.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Diagnostics;
-using System.Management.Automation;
 using Bicep.Core.SourceGraph;
 using Microsoft.Extensions.DependencyInjection;
 using PSBicep.Core.Services;
@@ -14,11 +13,11 @@ public class PSBicep
     public readonly BicepRegistryService registryService;
     public readonly string bicepVersion;
 
-    public PSBicep(PSCmdlet cmdlet)
+    public PSBicep()
     {
         _services = new ServiceCollection()
             .AddBicepCore()
-            .AddPSBicep(cmdlet)
+            .AddPSBicep()
             .BuildServiceProvider();
         coreService = _services.GetRequiredService<BicepCoreService>();
         registryService = _services.GetRequiredService<BicepRegistryService>();

--- a/PSBicep.Core/ServiceCollectionExtensions.cs
+++ b/PSBicep.Core/ServiceCollectionExtensions.cs
@@ -1,5 +1,4 @@
 using System.IO.Abstractions;
-using System.Management.Automation;
 using Azure.Bicep.Types;
 using Azure.Bicep.Types.Az;
 using Bicep.Core;
@@ -20,7 +19,6 @@ using Bicep.Decompiler;
 using Bicep.IO.Abstraction;
 using Bicep.IO.FileSystem;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.Threading;
 using PSBicep.Core.Authentication;
 using PSBicep.Core.Configuration;
@@ -33,10 +31,8 @@ namespace PSBicep.Core;
 
 public static class ServiceCollectionExtensions
 {
-    public static IServiceCollection AddPSBicep(this IServiceCollection services, PSCmdlet cmdlet) => services
-        .AddSingleton(cmdlet)
+    public static IServiceCollection AddPSBicep(this IServiceCollection services) => services
         .AddSingleton<DiagnosticLogger>()
-        .AddSingleton<ILogger>(s => s.GetRequiredService<DiagnosticLogger>())
         .AddSingleton<ITypeLoader, AzTypeLoader>()
         .AddSingleton<AzResourceTypeLoader>()
         .AddSingleton<Workspace>()

--- a/PSBicep/Commands/BaseCommand.cs
+++ b/PSBicep/Commands/BaseCommand.cs
@@ -1,4 +1,5 @@
 ﻿using System.Management.Automation;
+using PSBicep.LoadContext;
 
 namespace PSBicep.Commands;
 
@@ -10,7 +11,14 @@ public class BaseCommand : PSCmdlet
     protected override void BeginProcessing()
     {
         base.BeginProcessing();
-        psBicep = new Core.PSBicep(this);
+        psBicep = BicepLoader.PSBicep;
+        psBicep.coreService.InitializeLogger(this);
+    }
+
+    protected override void EndProcessing()
+    {
+        base.EndProcessing();
+        psBicep.coreService.UnloadLogger();
     }
 
     protected void SetAuthentication(string token)

--- a/PSBicep/LoadContext/BicepLoader.cs
+++ b/PSBicep/LoadContext/BicepLoader.cs
@@ -1,0 +1,23 @@
+namespace PSBicep.LoadContext;
+
+public static class BicepLoader
+{
+    private static Core.PSBicep _psBicep;
+    private static readonly object _initLock = new object();
+
+    public static Core.PSBicep PSBicep
+    {
+        get
+        {
+            if (_psBicep == null)
+            {
+                lock (_initLock)
+                {
+                    _psBicep ??= new Core.PSBicep();
+                }
+            }
+            return _psBicep;
+        }
+        set => _psBicep = value;
+    }
+}


### PR DESCRIPTION
Fixes #364

# Contributing a Pull Request

If you haven't already, read the full [contribution guide](https://github.com/PSBicep/PSBicep/blob/main/CONTRIBUTING.md). The guide may have changed since the last time you read it, so please double-check. Once you are done and ready to submit your PR, run through the relevant checklist below.

## Overview/Summary

Fixes #364 

Replace this with a brief description of what this Pull Request fixes, changes, etc.

## This PR fixes/adds/changes/removes

1. Removed ILogger and PSCmdlet from DependencyInjection in PSBicep.Core
2. Added methods for Initialize and Unload to DiagnosticLogger to be able to load/unload a PSCmdlet at runtime
3. Replace any ILogger reference with diagnosticLogger.Log() method.
4. Added a static BicepLoader class to the PSBicep project that lazy-loads the PSBicep Service if not loaded and acts as a singleton.

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/PSBicep/PSBicep/pulls)
- [x] Associated it with relevant [issues](https://github.com/PSBicep/PSBicep/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/PSBicep/PSBicep/tree/main)
- [x] Performed testing.
- [x] Verified build scripts work.
- [x] Updated relevant and associated documentation.
